### PR TITLE
fix: resolve test compilation errors from ModelFile API mismatch

### DIFF
--- a/src/model_file.rs
+++ b/src/model_file.rs
@@ -17,9 +17,28 @@ pub struct ModelFile {
 
 impl ModelFile {
     /// Creates a new model file
-    
+
     pub fn new(model: Model, content: String, file_name: String) -> Self {
         ModelFile { model, content, file_name }
+    }
+
+    /// Creates a new model file from a namespace and optional version.
+    /// Convenience constructor for tests and simple use cases.
+    pub fn from_namespace(namespace: String, version: Option<String>) -> Self {
+        let model = Model {
+            _class: "concerto.metamodel@1.0.0.Model".to_string(),
+            namespace,
+            source_uri: None,
+            concerto_version: version,
+            imports: None,
+            declarations: None,
+            decorators: None,
+        };
+        ModelFile {
+            model,
+            content: String::new(),
+            file_name: String::new(),
+        }
     }
     pub fn get_name(&self) -> String {
         self.model.namespace.clone()

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -12,7 +12,7 @@ fn test_conformance_system_property_name() {
     // Test: Property name uses system-reserved name
 
     // Create a model file
-    let mut model_file = ModelFile::new("org.example".to_string(), Some("1.0.0".to_string()));
+    let mut model_file = ModelFile::from_namespace("org.example".to_string(), Some("1.0.0".to_string()));
 
     // Create a concept declaration with a property that has a reserved name
     let concept_decl = ConceptDeclaration {
@@ -59,7 +59,7 @@ fn test_conformance_duplicate_declaration() {
     // Test: Duplicate declaration names in the same model
 
     // Create a model file
-    let mut model_file = ModelFile::new("org.example".to_string(), Some("1.0.0".to_string()));
+    let mut model_file = ModelFile::from_namespace("org.example".to_string(), Some("1.0.0".to_string()));
 
     // First declaration
     let concept_decl1 = ConceptDeclaration {
@@ -119,7 +119,7 @@ fn test_conformance_circular_inheritance() {
     let mut model_manager = ModelManager::new(true);
 
     // Create a model file
-    let mut model_file = ModelFile::new("org.example".to_string(), Some("1.0.0".to_string()));
+    let mut model_file = ModelFile::from_namespace("org.example".to_string(), Some("1.0.0".to_string()));
 
     // Person extends Employee
     let concept_decl1 = ConceptDeclaration {
@@ -190,7 +190,7 @@ fn test_conformance_property_duplicate_names() {
     // Test: Duplicate property names in a declaration
 
     // Create a model file
-    let mut model_file = ModelFile::new("org.example".to_string(), Some("1.0.0".to_string()));
+    let mut model_file = ModelFile::from_namespace("org.example".to_string(), Some("1.0.0".to_string()));
 
     // Create a concept with duplicate property names
     let concept_decl = ConceptDeclaration {

--- a/tests/namespace_tests.rs
+++ b/tests/namespace_tests.rs
@@ -8,7 +8,7 @@ use concerto_core::validation::Validate;
 #[test]
 fn test_valid_namespace_format() {
     // Create a model file with a valid namespace format
-    let model_file = ModelFile::new("org.example.model".to_string(), Some("1.0.0".to_string()));
+    let model_file = ModelFile::from_namespace("org.example.model".to_string(), Some("1.0.0".to_string()));
 
     // Should pass validation
     let result = model_file.validate();
@@ -18,7 +18,7 @@ fn test_valid_namespace_format() {
 #[test]
 fn test_empty_namespace() {
     // Create a model file with an empty namespace
-    let model_file = ModelFile::new("".to_string(), Some("1.0.0".to_string()));
+    let model_file = ModelFile::from_namespace("".to_string(), Some("1.0.0".to_string()));
 
     // Should fail validation with message about empty namespace
     let result = model_file.validate();
@@ -30,7 +30,7 @@ fn test_empty_namespace() {
 #[ignore]
 fn test_duplicate_namespace_imports() {
     // Create a model file
-    let mut model_file = ModelFile::new("org.example".to_string(), Some("1.0.0".to_string()));
+    let mut model_file = ModelFile::from_namespace("org.example".to_string(), Some("1.0.0".to_string()));
 
     // Add duplicate imports
     let import1 = Import {
@@ -59,7 +59,7 @@ fn test_duplicate_namespace_imports() {
 #[test]
 fn test_valid_imports() {
     // Create a model file
-    let mut model_file = ModelFile::new("org.example".to_string(), Some("1.0.0".to_string()));
+    let mut model_file = ModelFile::from_namespace("org.example".to_string(), Some("1.0.0".to_string()));
 
     // Add valid imports with different namespaces
     let import1 = Import {
@@ -85,7 +85,7 @@ fn test_valid_imports() {
 #[test]
 fn test_import_with_version() {
     // Create a model file
-    let mut model_file = ModelFile::new("org.example".to_string(), Some("1.0.0".to_string()));
+    let mut model_file = ModelFile::from_namespace("org.example".to_string(), Some("1.0.0".to_string()));
 
     // Add import with version
     let import = Import {


### PR DESCRIPTION
# No corresponding issue
ModelFile::new() was updated to take 3 arguments (Model, content, file_name), but several test files still used the old 2-argument signature. This caused namespace_tests and conformance_tests to fail to compile.

### Changes
- Added `ModelFile::from_namespace()` convenience constructor for creating a ModelFile from a namespace and optional version
- Updated `namespace_tests.rs` and `conformance_tests.rs` to use `from_namespace()` instead of the old 2-argument `ModelFile::new()` signature

### Flags
- The old `ModelFile::new(Model, String, String)` is unchanged — `from_namespace()` is additive only

### Screenshots or Video
N/A — all 23 tests now compile; 16 pass, 7 remain `#[ignore]` pending implementation

### Related Issues
N/A

### Author Checklist
- [x] DCO sign-off provided
- [x] Commits follow AP format
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:fix/test-compilation`
