### PR TITLE
fix: property validation via serde flatten (partial #4)

### DIFF
--- a/src/metamodel/concerto_metamodel_1_0_0.rs
+++ b/src/metamodel/concerto_metamodel_1_0_0.rs
@@ -235,24 +235,11 @@ pub struct Declaration {
    )]
    pub location: Option<Range>,
 
-   /// Captures all additional fields from the JSON (properties, isAbstract, superType, etc.)
-   /// that are specific to declaration subtypes (ConceptDeclaration, EnumDeclaration, etc.)
-   #[serde(
-      flatten,
-   )]
+   // TODO: move this to concerto-codegen rustvisitor.js
+   // Captures subtype-specific fields (properties, isAbstract, superType, etc.)
+   // that would otherwise be dropped during deserialization
+   #[serde(flatten)]
    pub extra: std::collections::HashMap<String, serde_json::Value>,
-}
-
-impl Declaration {
-   /// Extracts properties from the flattened extra fields.
-   /// Returns an empty Vec if no properties are present (e.g., for EnumDeclaration, MapDeclaration).
-   pub fn get_properties(&self) -> Vec<Property> {
-      if let Some(props_val) = self.extra.get("properties") {
-         serde_json::from_value::<Vec<Property>>(props_val.clone()).unwrap_or_default()
-      } else {
-         Vec::new()
-      }
-   }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/metamodel/concerto_metamodel_1_0_0.rs
+++ b/src/metamodel/concerto_metamodel_1_0_0.rs
@@ -234,6 +234,25 @@ pub struct Declaration {
       skip_serializing_if = "Option::is_none",
    )]
    pub location: Option<Range>,
+
+   /// Captures all additional fields from the JSON (properties, isAbstract, superType, etc.)
+   /// that are specific to declaration subtypes (ConceptDeclaration, EnumDeclaration, etc.)
+   #[serde(
+      flatten,
+   )]
+   pub extra: std::collections::HashMap<String, serde_json::Value>,
+}
+
+impl Declaration {
+   /// Extracts properties from the flattened extra fields.
+   /// Returns an empty Vec if no properties are present (e.g., for EnumDeclaration, MapDeclaration).
+   pub fn get_properties(&self) -> Vec<Property> {
+      if let Some(props_val) = self.extra.get("properties") {
+         serde_json::from_value::<Vec<Property>>(props_val.clone()).unwrap_or_default()
+      } else {
+         Vec::new()
+      }
+   }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/metamodel/declaration_ext.rs
+++ b/src/metamodel/declaration_ext.rs
@@ -1,0 +1,13 @@
+use super::concerto_metamodel_1_0_0::{Declaration, Property};
+
+impl Declaration {
+    /// Extracts properties from the flattened extra fields.
+    /// Returns an empty Vec if no properties are present (e.g., for EnumDeclaration, MapDeclaration).
+    pub fn get_properties(&self) -> Vec<Property> {
+        if let Some(props_val) = self.extra.get("properties") {
+            serde_json::from_value::<Vec<Property>>(props_val.clone()).unwrap_or_default()
+        } else {
+            Vec::new()
+        }
+    }
+}

--- a/src/metamodel/mod.rs
+++ b/src/metamodel/mod.rs
@@ -6,5 +6,6 @@ pub mod concerto_1_0_0;
 pub mod concerto;
 #[allow(unused_imports)]
 pub mod concerto_metamodel_1_0_0;
+pub mod declaration_ext;
 #[allow(unused_imports)]
 pub mod utils;

--- a/src/metamodel_validation.rs
+++ b/src/metamodel_validation.rs
@@ -213,19 +213,14 @@ impl Validate for ScalarDeclaration {
 
 impl Validate for Property {
     fn validate(&self) -> Result<(), ConcertoError> {
-        // For the standalone Validate trait, we'll do basic validation
-        // The PropertyValidator trait is for validation within a model context
+        // Check for system-reserved property names first (before general identifier check)
+        if self.name.starts_with('$') {
+            return Err(ConcertoError::ValidationError(format!("Invalid field name '{}'. Property names starting with $ are reserved for system use", self.name)));
+        }
 
         // Validate property name
         if !is_valid_identifier(&self.name) {
             return Err(ConcertoError::ValidationError(format!("'{}' is not a valid property name. Identifiers must start with a letter and can contain only letters, numbers, or underscores", self.name)));
-        }
-
-        // TODO check for other reserved names
-
-        // Check for system-reserved property names
-        if self.name.starts_with('$') {
-            return Err(ConcertoError::ValidationError(format!("Invalid field name '{}'. Property names starting with $ are reserved for system use", self.name)));
         }
 
         // Validate decorators if present

--- a/src/metamodel_validation.rs
+++ b/src/metamodel_validation.rs
@@ -213,7 +213,7 @@ impl Validate for ScalarDeclaration {
 
 impl Validate for Property {
     fn validate(&self) -> Result<(), ConcertoError> {
-        // Check for system-reserved property names first (before general identifier check)
+        // All user-defined properties starting with $ are reserved for system use
         if self.name.starts_with('$') {
             return Err(ConcertoError::ValidationError(format!("Invalid field name '{}'. Property names starting with $ are reserved for system use", self.name)));
         }

--- a/src/model_file.rs
+++ b/src/model_file.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::fs;
 
 use crate::error::ConcertoError;
-use crate::metamodel::concerto_metamodel_1_0_0::{Model, Import, Declaration, Property};
+use crate::metamodel::concerto_metamodel_1_0_0::{Model, Import, Declaration};
 use crate::validation::Validate;
 
 /// Represents a Concerto model file
@@ -94,30 +94,6 @@ impl ModelFile {
         }
     }
 
-    /// Helper function to find properties for a declaration
-    /// In a real implementation, this would use proper type information and downcasting
-    /// This is a simplified approach just for the test case
-    pub fn find_properties_for_declaration(&self, declaration: &Declaration) -> Vec<Property> {
-        // For the test case, we have the properties separately in the test file
-        // We're looking specifically for the test where a property name is "$class"
-
-        let mut properties = Vec::new();
-
-        // Special case for our test
-        if declaration.name == "Person" && declaration._class.contains("ConceptDeclaration") {
-            // In test_conformance_system_property_name, we add a property with name "$class"
-            properties.push(Property {
-                _class: "concerto.metamodel@1.0.0.StringProperty".to_string(),
-                name: "$class".to_string(),
-                is_array: false,
-                is_optional: false,
-                decorators: None,
-                location: None,
-            });
-        }
-
-        properties
-    }
 }
 
 impl Validate for ModelFile {
@@ -125,23 +101,19 @@ impl Validate for ModelFile {
         // Validate the model structure first
         self.model.validate()?;
 
-        // Additional validation for system property names in concept declarations
+        // Validate properties within concept-like declarations
         if let Some(declarations) = &self.model.declarations {
             for declaration in declarations {
-                // For each declaration, check if it's a ConceptDeclaration by its class name
-                if declaration._class.contains("ConceptDeclaration") {
-                    // In a real implementation, this would use proper downcasting
-                    // For now, we'll manually check any conceptual properties
-
-                    // Look for the actual ConceptDeclaration in our test case
-                    // This is a simplified approach just for the test
-                    for prop in self.find_properties_for_declaration(declaration).iter() {
-                        // Validate each property
-                        if prop.name.starts_with('$') {
-                            return Err(ConcertoError::ValidationError(
-                                format!("Invalid field name '{}'. Property names starting with $ are reserved for system use", prop.name)
-                            ));
-                        }
+                // Check concept-like declarations that have properties
+                if declaration._class.contains("ConceptDeclaration")
+                    || declaration._class.contains("AssetDeclaration")
+                    || declaration._class.contains("ParticipantDeclaration")
+                    || declaration._class.contains("TransactionDeclaration")
+                    || declaration._class.contains("EventDeclaration")
+                {
+                    let properties = declaration.get_properties();
+                    for prop in &properties {
+                        prop.validate()?;
                     }
                 }
             }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -537,8 +537,13 @@ impl CommonDeclarationValidator {
     /// Helper function to validate decorators
     pub fn validate_decorators(decorators: &Option<Vec<Decorator>>) -> Result<(), ConcertoError> {
         if let Some(decs) = decorators {
+            let mut seen = std::collections::HashSet::new();
             for decorator in decs {
-                // Use the Validate trait for each decorator
+                if !seen.insert(&decorator.name) {
+                    return Err(ConcertoError::ValidationError(
+                        format!("Duplicate decorator: {}", decorator.name)
+                    ));
+                }
                 use crate::validation::Validate;
                 decorator.validate()?;
             }
@@ -978,15 +983,55 @@ impl DeclarationValidator for DateTimeScalar {
 // Add Validate implementations for all scalar types
 impl Validate for StringScalar {
     fn validate(&self) -> Result<(), ConcertoError> {
-        // Use the DeclarationValidator trait we implemented
-        self.validate_declaration()
+        self.validate_declaration()?;
+
+        // Validate length bounds
+        if let Some(ref length_validator) = self.length_validator {
+            // Both bounds must be non-negative
+            if let Some(min) = length_validator.min_length {
+                if min < 0 {
+                    return Err(ConcertoError::ValidationError(
+                        "minLength and/or maxLength must be positive integers".to_string()
+                    ));
+                }
+            }
+            if let Some(max) = length_validator.max_length {
+                if max < 0 {
+                    return Err(ConcertoError::ValidationError(
+                        "minLength and/or maxLength must be positive integers".to_string()
+                    ));
+                }
+            }
+            // minLength must be <= maxLength
+            if let (Some(min), Some(max)) = (length_validator.min_length, length_validator.max_length) {
+                if min > max {
+                    return Err(ConcertoError::ValidationError(
+                        format!("minLength {} must be less than or equal to maxLength {}", min, max)
+                    ));
+                }
+            }
+        }
+
+        Ok(())
     }
 }
 
 impl Validate for IntegerScalar {
     fn validate(&self) -> Result<(), ConcertoError> {
-        // Use the DeclarationValidator trait we implemented
-        self.validate_declaration()
+        self.validate_declaration()?;
+
+        // Validate bounds: lower must be <= upper
+        if let Some(ref validator) = self.validator {
+            if let (Some(lower), Some(upper)) = (validator.lower, validator.upper) {
+                if lower > upper {
+                    return Err(ConcertoError::ValidationError(
+                        format!("Lower bound {} must be less than or equal to upper bound {}", lower, upper)
+                    ));
+                }
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -35,12 +35,18 @@ fn test_conformance_system_property_name() {
         location: None,
     };
 
-    // Convert ConceptDeclaration to Declaration
+    // Convert ConceptDeclaration to Declaration, preserving properties in extra
     let declaration = Declaration {
         _class: concept_decl._class.clone(),
         name: concept_decl.name.clone(),
         decorators: concept_decl.decorators.clone(),
         location: concept_decl.location.clone(),
+        extra: {
+            let mut map = std::collections::HashMap::new();
+            map.insert("properties".to_string(), serde_json::to_value(&concept_decl.properties).unwrap());
+            map.insert("isAbstract".to_string(), serde_json::Value::Bool(concept_decl.is_abstract));
+            map
+        },
     };
 
     // Add the declaration to the model file
@@ -50,8 +56,6 @@ fn test_conformance_system_property_name() {
     let result = model_file.validate();
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("Invalid"));
-
-
 }
 
 #[test]
@@ -61,43 +65,21 @@ fn test_conformance_duplicate_declaration() {
     // Create a model file
     let mut model_file = ModelFile::new("org.example".to_string(), Some("1.0.0".to_string()));
 
-    // First declaration
-    let concept_decl1 = ConceptDeclaration {
-        _class: "concerto.metamodel@1.0.0.ConceptDeclaration".to_string(),
-        name: "Person".to_string(),
-        super_type: None,
-        properties: vec![],
-        decorators: None,
-        is_abstract: false,
-        identified: None,
-        location: None,
-    };
-
-    // Second declaration with same name
-    let concept_decl2 = ConceptDeclaration {
-        _class: "concerto.metamodel@1.0.0.ConceptDeclaration".to_string(),
-        name: "Person".to_string(),
-        super_type: None,
-        properties: vec![],
-        decorators: None,
-        is_abstract: false,
-        identified: None,
-        location: None,
-    };
-
     // Convert ConceptDeclarations to Declarations
     let declaration1 = Declaration {
-        _class: concept_decl1._class.clone(),
-        name: concept_decl1.name.clone(),
-        decorators: concept_decl1.decorators.clone(),
-        location: concept_decl1.location.clone(),
+        _class: "concerto.metamodel@1.0.0.ConceptDeclaration".to_string(),
+        name: "Person".to_string(),
+        decorators: None,
+        location: None,
+        extra: Default::default(),
     };
 
     let declaration2 = Declaration {
-        _class: concept_decl2._class.clone(),
-        name: concept_decl2.name.clone(),
-        decorators: concept_decl2.decorators.clone(),
-        location: concept_decl2.location.clone(),
+        _class: "concerto.metamodel@1.0.0.ConceptDeclaration".to_string(),
+        name: "Person".to_string(),
+        decorators: None,
+        location: None,
+        extra: Default::default(),
     };
 
     // Add both declarations to the model file
@@ -121,51 +103,21 @@ fn test_conformance_circular_inheritance() {
     // Create a model file
     let mut model_file = ModelFile::new("org.example".to_string(), Some("1.0.0".to_string()));
 
-    // Person extends Employee
-    let concept_decl1 = ConceptDeclaration {
-        _class: "concerto.metamodel@1.0.0.ConceptDeclaration".to_string(),
-        name: "Person".to_string(),
-        super_type: Some(TypeIdentifier {
-            _class: "concerto.metamodel@1.0.0.TypeIdentifier".to_string(),
-            name: "Employee".to_string(),
-            namespace: Some("org.example".to_string()),
-        }),
-        properties: vec![],
-        decorators: None,
-        is_abstract: false,
-        identified: None,
-        location: None,
-    };
-
-    // Employee extends Person (circular)
-    let concept_decl2 = ConceptDeclaration {
-        _class: "concerto.metamodel@1.0.0.ConceptDeclaration".to_string(),
-        name: "Employee".to_string(),
-        super_type: Some(TypeIdentifier {
-            _class: "concerto.metamodel@1.0.0.TypeIdentifier".to_string(),
-            name: "Person".to_string(),
-            namespace: Some("org.example".to_string()),
-        }),
-        properties: vec![],
-        decorators: None,
-        is_abstract: false,
-        identified: None,
-        location: None,
-    };
-
     // Convert ConceptDeclarations to Declarations
     let declaration1 = Declaration {
-        _class: concept_decl1._class.clone(),
-        name: concept_decl1.name.clone(),
-        decorators: concept_decl1.decorators.clone(),
-        location: concept_decl1.location.clone(),
+        _class: "concerto.metamodel@1.0.0.ConceptDeclaration".to_string(),
+        name: "Person".to_string(),
+        decorators: None,
+        location: None,
+        extra: Default::default(),
     };
 
     let declaration2 = Declaration {
-        _class: concept_decl2._class.clone(),
-        name: concept_decl2.name.clone(),
-        decorators: concept_decl2.decorators.clone(),
-        location: concept_decl2.location.clone(),
+        _class: "concerto.metamodel@1.0.0.ConceptDeclaration".to_string(),
+        name: "Employee".to_string(),
+        decorators: None,
+        location: None,
+        extra: Default::default(),
     };
 
     // Add both declarations to the model file
@@ -188,9 +140,6 @@ fn test_conformance_circular_inheritance() {
 #[test]
 fn test_conformance_property_duplicate_names() {
     // Test: Duplicate property names in a declaration
-
-    // Create a model file
-    let mut model_file = ModelFile::new("org.example".to_string(), Some("1.0.0".to_string()));
 
     // Create a concept with duplicate property names
     let concept_decl = ConceptDeclaration {
@@ -227,8 +176,4 @@ fn test_conformance_property_duplicate_names() {
     let concept_result = concept_decl.validate();
     assert!(concept_result.is_err());
     assert!(concept_result.unwrap_err().to_string().contains("Duplicate property"));
-
-    // The ModelFile test is not needed since we've already verified the validation works directly
-    // If needed in a real implementation, we would need to ensure ModelFile validation
-    // properly traverses and validates the full ConceptDeclaration structure
 }

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -2,7 +2,7 @@
 
 use concerto_core::model_file::ModelFile;
 use concerto_core::metamodel::concerto_metamodel_1_0_0::{
-    ConceptDeclaration, Declaration, Property, TypeIdentifier
+    ConceptDeclaration, Declaration, Property
 };
 use concerto_core::validation::Validate;
 use concerto_core::model_manager::ModelManager;
@@ -10,11 +10,8 @@ use concerto_core::model_manager::ModelManager;
 #[test]
 fn test_conformance_system_property_name() {
     // Test: Property name uses system-reserved name
-
-    // Create a model file
     let mut model_file = ModelFile::from_namespace("org.example".to_string(), Some("1.0.0".to_string()));
 
-    // Create a concept declaration with a property that has a reserved name
     let concept_decl = ConceptDeclaration {
         _class: "concerto.metamodel@1.0.0.ConceptDeclaration".to_string(),
         name: "Person".to_string(),
@@ -22,7 +19,7 @@ fn test_conformance_system_property_name() {
         properties: vec![
             Property {
                 _class: "concerto.metamodel@1.0.0.StringProperty".to_string(),
-                name: "$class".to_string(),  // System-reserved name
+                name: "$class".to_string(),
                 is_array: false,
                 is_optional: false,
                 decorators: None,
@@ -35,7 +32,7 @@ fn test_conformance_system_property_name() {
         location: None,
     };
 
-    // Convert ConceptDeclaration to Declaration, preserving properties in extra
+    // Convert to Declaration, preserving properties in extra
     let declaration = Declaration {
         _class: concept_decl._class.clone(),
         name: concept_decl.name.clone(),
@@ -49,10 +46,8 @@ fn test_conformance_system_property_name() {
         },
     };
 
-    // Add the declaration to the model file
     model_file.add_declaration(declaration);
 
-    // Should fail validation with message about invalid field name
     let result = model_file.validate();
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("Invalid"));
@@ -61,11 +56,8 @@ fn test_conformance_system_property_name() {
 #[test]
 fn test_conformance_duplicate_declaration() {
     // Test: Duplicate declaration names in the same model
-
-    // Create a model file
     let mut model_file = ModelFile::from_namespace("org.example".to_string(), Some("1.0.0".to_string()));
 
-    // Convert ConceptDeclarations to Declarations
     let declaration1 = Declaration {
         _class: "concerto.metamodel@1.0.0.ConceptDeclaration".to_string(),
         name: "Person".to_string(),
@@ -82,11 +74,9 @@ fn test_conformance_duplicate_declaration() {
         extra: Default::default(),
     };
 
-    // Add both declarations to the model file
     model_file.add_declaration(declaration1);
     model_file.add_declaration(declaration2);
 
-    // Should fail validation with message about duplicate class name
     let result = model_file.validate();
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("Duplicate"));
@@ -96,14 +86,9 @@ fn test_conformance_duplicate_declaration() {
 #[ignore]
 fn test_conformance_circular_inheritance() {
     // Test: Circular inheritance detection
-
-    // Create a model manager
     let mut model_manager = ModelManager::new(true);
-
-    // Create a model file
     let mut model_file = ModelFile::from_namespace("org.example".to_string(), Some("1.0.0".to_string()));
 
-    // Convert ConceptDeclarations to Declarations
     let declaration1 = Declaration {
         _class: "concerto.metamodel@1.0.0.ConceptDeclaration".to_string(),
         name: "Person".to_string(),
@@ -120,19 +105,14 @@ fn test_conformance_circular_inheritance() {
         extra: Default::default(),
     };
 
-    // Add both declarations to the model file
     model_file.add_declaration(declaration1);
     model_file.add_declaration(declaration2);
 
-    // Add the model file to the model manager
     let result = model_manager.add_model_file(model_file);
     assert!(result.is_ok());
 
-    // Should fail validation with message about circular inheritance
     let result = model_manager.validate_models();
     assert!(result.is_err());
-
-    // Get the error message
     let error_message = result.unwrap_err().to_string();
     assert!(error_message.contains("circular") || error_message.contains("Circular"));
 }
@@ -140,17 +120,11 @@ fn test_conformance_circular_inheritance() {
 #[test]
 fn test_conformance_property_duplicate_names() {
     // Test: Duplicate property names in a declaration
-
-    // Create a model file
-    let mut model_file = ModelFile::from_namespace("org.example".to_string(), Some("1.0.0".to_string()));
-
-    // Create a concept with duplicate property names
     let concept_decl = ConceptDeclaration {
         _class: "concerto.metamodel@1.0.0.ConceptDeclaration".to_string(),
         name: "Person".to_string(),
         super_type: None,
         properties: vec![
-            // First property
             Property {
                 _class: "concerto.metamodel@1.0.0.StringProperty".to_string(),
                 name: "name".to_string(),
@@ -159,7 +133,6 @@ fn test_conformance_property_duplicate_names() {
                 decorators: None,
                 location: None,
             },
-            // Duplicate property with same name
             Property {
                 _class: "concerto.metamodel@1.0.0.StringProperty".to_string(),
                 name: "name".to_string(),
@@ -175,7 +148,6 @@ fn test_conformance_property_duplicate_names() {
         location: None,
     };
 
-    // First, directly validate the ConceptDeclaration which should fail due to duplicate properties
     let concept_result = concept_decl.validate();
     assert!(concept_result.is_err());
     assert!(concept_result.unwrap_err().to_string().contains("Duplicate property"));

--- a/tests/declaration_tests.rs
+++ b/tests/declaration_tests.rs
@@ -40,6 +40,7 @@ fn test_declaration_validation() {
         name: concept_decl.name.clone(),
         decorators: concept_decl.decorators.clone(),
         location: concept_decl.location.clone(),
+        extra: Default::default(),
     };
 
     // Validate the declaration
@@ -64,6 +65,7 @@ fn test_declaration_validation() {
         name: invalid_concept_decl.name.clone(),
         decorators: invalid_concept_decl.decorators.clone(),
         location: invalid_concept_decl.location.clone(),
+        extra: Default::default(),
     };
 
     let result = invalid_declaration.validate();

--- a/tests/enum_tests.rs
+++ b/tests/enum_tests.rs
@@ -42,6 +42,7 @@ fn test_enum_with_duplicate_values() {
         name: enum_decl.name.clone(),
         decorators: enum_decl.decorators.clone(),
         location: enum_decl.location.clone(),
+        extra: Default::default(),
     };
 
     // Should fail validation with "Duplicate enum value"
@@ -61,6 +62,7 @@ fn test_enum_with_valid_values() {
         name: enum_decl.name.clone(),
         decorators: enum_decl.decorators.clone(),
         location: enum_decl.location.clone(),
+        extra: Default::default(),
     };
 
     // Should pass validation
@@ -86,6 +88,7 @@ fn test_enum_with_empty_values() {
         name: enum_decl.name.clone(),
         decorators: enum_decl.decorators.clone(),
         location: enum_decl.location.clone(),
+        extra: Default::default(),
     };
 
     // Should fail validation with a message about needing at least one value
@@ -119,6 +122,7 @@ fn test_enum_with_invalid_property_name() {
         name: enum_decl.name.clone(),
         decorators: enum_decl.decorators.clone(),
         location: enum_decl.location.clone(),
+        extra: Default::default(),
     };
 
     // Should fail validation with message about invalid identifier

--- a/tests/map_tests.rs
+++ b/tests/map_tests.rs
@@ -31,6 +31,7 @@ fn test_map_with_valid_string_key() {
         name: map_decl.name.clone(),
         decorators: map_decl.decorators.clone(),
         location: map_decl.location.clone(),
+        extra: Default::default(),
     };
 
     // Should pass validation
@@ -64,6 +65,7 @@ fn test_map_with_datetime_key() {
         name: map_decl.name.clone(),
         decorators: map_decl.decorators.clone(),
         location: map_decl.location.clone(),
+        extra: Default::default(),
     };
 
     // Should pass validation
@@ -97,6 +99,7 @@ fn test_map_with_missing_key() {
         name: map_decl.name.clone(),
         decorators: map_decl.decorators.clone(),
         location: map_decl.location.clone(),
+        extra: Default::default(),
     };
 
     // Should fail validation due to empty name
@@ -132,6 +135,7 @@ fn test_map_with_missing_value() {
         name: map_decl.name.clone(),
         decorators: map_decl.decorators.clone(),
         location: map_decl.location.clone(),
+        extra: Default::default(),
     };
 
     // Should fail validation due to empty class name

--- a/tests/scalar_tests.rs
+++ b/tests/scalar_tests.rs
@@ -28,7 +28,6 @@ fn test_scalar_with_valid_number_bounds() {
 }
 
 #[test]
-#[ignore]
 fn test_scalar_with_invalid_number_bounds() {
     // Create a scalar with lower > upper
     let scalar_decl = IntegerScalar {
@@ -44,20 +43,8 @@ fn test_scalar_with_invalid_number_bounds() {
         default_value: None,
     };
 
-    // Create a declaration
-    let declaration = Declaration {
-        _class: scalar_decl._class.clone(),
-        name: scalar_decl.name.clone(),
-        decorators: scalar_decl.decorators.clone(),
-        location: scalar_decl.location.clone(),
-        extra: Default::default(),
-    };
-
-    // Should fail validation with message about bounds
-    // Note: The exact validation message may differ based on implementation
-    let result = declaration.validate();
+    let result = scalar_decl.validate();
     assert!(result.is_err());
-    // The error message should contain something about bounds
     assert!(result.unwrap_err().to_string().contains("bound"));
 }
 

--- a/tests/scalar_tests.rs
+++ b/tests/scalar_tests.rs
@@ -50,6 +50,7 @@ fn test_scalar_with_invalid_number_bounds() {
         name: scalar_decl.name.clone(),
         decorators: scalar_decl.decorators.clone(),
         location: scalar_decl.location.clone(),
+        extra: Default::default(),
     };
 
     // Should fail validation with message about bounds
@@ -83,6 +84,7 @@ fn test_scalar_with_string_validator() {
         name: scalar_decl.name.clone(),
         decorators: scalar_decl.decorators.clone(),
         location: scalar_decl.location.clone(),
+        extra: Default::default(),
     };
 
     // Should pass validation
@@ -109,6 +111,7 @@ fn test_scalar_with_invalid_name() {
         name: scalar_decl.name.clone(),
         decorators: scalar_decl.decorators.clone(),
         location: scalar_decl.location.clone(),
+        extra: Default::default(),
     };
 
     // Should fail validation with message about invalid identifier


### PR DESCRIPTION
# Partial fix for #4

### Changes
- Use `#[serde(flatten)]` on Declaration to preserve type-specific fields (properties, isAbstract, superType) during JSON deserialization
- Add `get_properties()` helper on Declaration, remove hardcoded `find_properties_for_declaration()` workaround
- Validate properties in all concept-like declarations (Concept, Asset, Participant, Transaction, Event)
- Validate scalar bounds: integer range ordering, string length non-negative and minLength ≤ maxLength
- Detect duplicate decorator names on declarations

### Flags
- Partial fix for #4, not closing it yet
- Scalar validator bounds and duplicate decorator checks now implemented
- $class false positive deferred — root cause is a deserialization issue with `#[serde(flatten)]` and nested `$class` discriminators, not validation logic

### Screenshots or Video
N/A

### Related Issues
- Issue #4

### Author Checklist
- [x] Ensure you provide a DCO sign-off for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow AP format
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `vyuan2037:fix/property-validation`
