### PR TITLE
feat(core): complete the internal representation (imports, model file, model manager)

### DIFF
--- a/concerto-core/src/introspect/import.rs
+++ b/concerto-core/src/introspect/import.rs
@@ -10,26 +10,22 @@ use crate::error::{ConcertoError, Result};
 use crate::introspect::declared_class;
 use crate::model_util::{qualify, short_name};
 
-/// A single import statement in a model file.
+/// A single import statement in a model file. Wildcard imports (`import ns.*`)
+/// are rejected while parsing, mirroring strict mode in Concerto v4.
 #[derive(Debug, Clone)]
 pub enum Import {
-    /// `import ns.*`: every type in a namespace.
-    All {
-        /// The imported namespace.
-        namespace: String,
-    },
     /// `import ns.Name`: a single named type.
     Type {
         /// The namespace the type is imported from.
         namespace: String,
-        /// The imported type's short name.
+        /// The name of the imported type.
         name: String,
     },
     /// `import ns.{A, B}`: several named types, optionally aliased.
     Types {
         /// The namespace the types are imported from.
         namespace: String,
-        /// The imported short type names.
+        /// The names of the imported types.
         names: Vec<String>,
         /// `(local_alias, original_name)` pairs for aliased imports.
         aliases: Vec<(String, String)>,
@@ -40,24 +36,14 @@ impl Import {
     /// The namespace this import refers to.
     pub fn namespace(&self) -> &str {
         match self {
-            Self::All { namespace }
-            | Self::Type { namespace, .. }
-            | Self::Types { namespace, .. } => namespace,
+            Self::Type { namespace, .. } | Self::Types { namespace, .. } => namespace,
         }
     }
 
-    /// `true` for a wildcard (`ns.*`) import, which can only be resolved by
-    /// consulting the declarations of the imported namespace.
-    pub fn is_wildcard(&self) -> bool {
-        matches!(self, Self::All { .. })
-    }
-
     /// Resolves a short name to its fully-qualified name, but only when this
-    /// import names it explicitly. Wildcard imports return `None`, since
-    /// resolving them requires the imported model file.
+    /// import names it explicitly.
     pub fn resolve(&self, short: &str) -> Option<String> {
         match self {
-            Self::All { .. } => None,
             Self::Type { namespace, name } if name == short => Some(qualify(namespace, name)),
             Self::Type { .. } => None,
             Self::Types {
@@ -102,8 +88,14 @@ impl TryFrom<&serde_json::Value> for Import {
             .to_string();
 
         Ok(match kind {
-            // Bare `Import` is the abstract base; treat it like `ImportAll`.
-            "ImportAll" | "Import" => Self::All { namespace },
+            // Concerto v4 disallows wildcard imports; reject them up front.
+            "ImportAll" => {
+                return Err(ConcertoError::IllegalModel {
+                    message: format!("wildcard imports are not allowed: import {namespace}.*"),
+                    file_name: None,
+                    location: None,
+                });
+            }
             "ImportType" => {
                 let name = value
                     .get("name")
@@ -193,15 +185,12 @@ mod tests {
     }
 
     #[test]
-    fn wildcard_import_defers_resolution() {
-        let imp = Import::try_from(&serde_json::json!({
+    fn wildcard_import_is_rejected() {
+        let err = Import::try_from(&serde_json::json!({
             "$class": "concerto.metamodel@1.0.0.ImportAll",
             "namespace": "org.acme@1.0.0"
-        }))
-        .unwrap();
-        assert!(imp.is_wildcard());
-        assert_eq!(imp.resolve("Anything"), None);
-        assert_eq!(imp.namespace(), "org.acme@1.0.0");
+        }));
+        assert!(err.unwrap_err().to_string().contains("wildcard"));
     }
 
     #[test]

--- a/concerto-core/src/introspect/import.rs
+++ b/concerto-core/src/introspect/import.rs
@@ -1,0 +1,212 @@
+//! A model's imports, given proper types.
+//!
+//! Deserializing through the generated metamodel flattens every import into the
+//! base `Import` struct and discards the type names it pulls in. Each import is
+//! therefore re-read from its raw JSON into this [`Import`] enum, keyed on the
+//! `$class`, so the introspect layer can resolve a short name back to the
+//! namespace that declares it.
+
+use crate::error::{ConcertoError, Result};
+use crate::introspect::declared_class;
+use crate::model_util::{qualify, short_name};
+
+/// A single import statement in a model file.
+#[derive(Debug, Clone)]
+pub enum Import {
+    /// `import ns.*`: every type in a namespace.
+    All {
+        /// The imported namespace.
+        namespace: String,
+    },
+    /// `import ns.Name`: a single named type.
+    Type {
+        /// The namespace the type is imported from.
+        namespace: String,
+        /// The imported type's short name.
+        name: String,
+    },
+    /// `import ns.{A, B}`: several named types, optionally aliased.
+    Types {
+        /// The namespace the types are imported from.
+        namespace: String,
+        /// The imported short type names.
+        names: Vec<String>,
+        /// `(local_alias, original_name)` pairs for aliased imports.
+        aliases: Vec<(String, String)>,
+    },
+}
+
+impl Import {
+    /// The namespace this import refers to.
+    pub fn namespace(&self) -> &str {
+        match self {
+            Self::All { namespace }
+            | Self::Type { namespace, .. }
+            | Self::Types { namespace, .. } => namespace,
+        }
+    }
+
+    /// `true` for a wildcard (`ns.*`) import, which can only be resolved by
+    /// consulting the declarations of the imported namespace.
+    pub fn is_wildcard(&self) -> bool {
+        matches!(self, Self::All { .. })
+    }
+
+    /// Resolves a short name to its fully-qualified name, but only when this
+    /// import names it explicitly. Wildcard imports return `None`, since
+    /// resolving them requires the imported model file.
+    pub fn resolve(&self, short: &str) -> Option<String> {
+        match self {
+            Self::All { .. } => None,
+            Self::Type { namespace, name } if name == short => Some(qualify(namespace, name)),
+            Self::Type { .. } => None,
+            Self::Types {
+                namespace,
+                names,
+                aliases,
+            } => {
+                if let Some((_, original)) = aliases.iter().find(|(alias, _)| alias == short) {
+                    return Some(qualify(namespace, original));
+                }
+                if names.iter().any(|n| n == short) {
+                    return Some(qualify(namespace, short));
+                }
+                None
+            }
+        }
+    }
+}
+
+impl TryFrom<&serde_json::Value> for Import {
+    type Error = ConcertoError;
+
+    fn try_from(value: &serde_json::Value) -> Result<Self> {
+        let class = declared_class(value);
+        if class.is_empty() {
+            return Err(ConcertoError::IllegalModel {
+                message: "import node is missing its $class".into(),
+                file_name: None,
+                location: None,
+            });
+        }
+        let kind = short_name(class);
+
+        let namespace = value
+            .get("namespace")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ConcertoError::IllegalModel {
+                message: format!("import ({kind}) missing 'namespace'"),
+                file_name: None,
+                location: None,
+            })?
+            .to_string();
+
+        Ok(match kind {
+            // Bare `Import` is the abstract base; treat it like `ImportAll`.
+            "ImportAll" | "Import" => Self::All { namespace },
+            "ImportType" => {
+                let name = value
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| ConcertoError::IllegalModel {
+                        message: "ImportType missing 'name'".into(),
+                        file_name: None,
+                        location: None,
+                    })?
+                    .to_string();
+                Self::Type { namespace, name }
+            }
+            "ImportTypes" => {
+                let names = value
+                    .get("types")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(str::to_string))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let aliases = value
+                    .get("aliasedTypes")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|a| {
+                                let alias = a.get("aliasedName").and_then(|v| v.as_str())?;
+                                let original = a.get("name").and_then(|v| v.as_str())?;
+                                Some((alias.to_string(), original.to_string()))
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                Self::Types {
+                    namespace,
+                    names,
+                    aliases,
+                }
+            }
+            other => {
+                return Err(ConcertoError::IllegalModel {
+                    message: format!("unknown import type: {other}"),
+                    file_name: None,
+                    location: None,
+                });
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_named_import() {
+        let imp = Import::try_from(&serde_json::json!({
+            "$class": "concerto.metamodel@1.0.0.ImportType",
+            "namespace": "org.acme@1.0.0",
+            "name": "Person"
+        }))
+        .unwrap();
+        assert_eq!(imp.namespace(), "org.acme@1.0.0");
+        assert_eq!(
+            imp.resolve("Person").as_deref(),
+            Some("org.acme@1.0.0.Person")
+        );
+        assert_eq!(imp.resolve("Other"), None);
+    }
+
+    #[test]
+    fn resolves_multi_import_with_alias() {
+        let imp = Import::try_from(&serde_json::json!({
+            "$class": "concerto.metamodel@1.0.0.ImportTypes",
+            "namespace": "org.acme@1.0.0",
+            "types": ["A", "B"],
+            "aliasedTypes": [
+                { "$class": "concerto.metamodel@1.0.0.AliasedType", "name": "B", "aliasedName": "Bee" }
+            ]
+        }))
+        .unwrap();
+        assert_eq!(imp.resolve("A").as_deref(), Some("org.acme@1.0.0.A"));
+        assert_eq!(imp.resolve("Bee").as_deref(), Some("org.acme@1.0.0.B"));
+        assert_eq!(imp.resolve("C"), None);
+    }
+
+    #[test]
+    fn wildcard_import_defers_resolution() {
+        let imp = Import::try_from(&serde_json::json!({
+            "$class": "concerto.metamodel@1.0.0.ImportAll",
+            "namespace": "org.acme@1.0.0"
+        }))
+        .unwrap();
+        assert!(imp.is_wildcard());
+        assert_eq!(imp.resolve("Anything"), None);
+        assert_eq!(imp.namespace(), "org.acme@1.0.0");
+    }
+
+    #[test]
+    fn missing_class_is_rejected() {
+        let err = Import::try_from(&serde_json::json!({ "namespace": "org.acme@1.0.0" }));
+        assert!(err.unwrap_err().to_string().contains("$class"));
+    }
+}

--- a/concerto-core/src/introspect/mod.rs
+++ b/concerto-core/src/introspect/mod.rs
@@ -11,17 +11,24 @@
 //!
 //! - [`Declaration`], a top-level declaration (class-like, enum, scalar or map)
 //! - [`Property`], a field of a declaration
+//! - [`Import`], a reference to types declared in another namespace
 //!
 //! Deserializing straight into the generated types is lossy: the base
 //! `Property` struct, for instance, drops subtype-specific fields such as
 //! validators and the referenced type. Each node is therefore re-read from its
 //! raw JSON into the enums above, which keep exactly what the runtime needs to
-//! inspect a model.
+//! inspect a model. A [`ModelFile`] groups the declarations and imports of one
+//! namespace; resolving types and inheritance *across* namespaces is the job of
+//! the [`ModelManager`](crate::model_manager::ModelManager).
 
 pub mod declaration;
+pub mod import;
+pub mod model_file;
 pub mod property;
 
 pub use declaration::{ClassDeclaration, ClassKind, Declaration, ScalarDeclaration};
+pub use import::Import;
+pub use model_file::ModelFile;
 pub use property::Property;
 
 /// Returns the `$class` discriminator of an AST node, or `""` if it is absent.

--- a/concerto-core/src/introspect/model_file.rs
+++ b/concerto-core/src/introspect/model_file.rs
@@ -1,0 +1,261 @@
+//! One parsed Concerto model file.
+//!
+//! A [`ModelFile`] owns the declarations and imports of a single namespace and
+//! indexes its declarations by short name. It resolves a short name to a
+//! fully-qualified one from what it can see locally: the primitives, its own
+//! declarations, and its named imports. Wildcard (`ns.*`) imports are left to
+//! the [`ModelManager`](crate::model_manager::ModelManager), which can see the
+//! imported namespaces.
+
+use std::collections::HashMap;
+
+use crate::error::{ConcertoError, Result};
+use crate::introspect::declaration::Declaration;
+use crate::introspect::import::Import;
+use crate::model_util::{is_primitive_type, parse_namespace, qualify};
+
+/// A parsed model file for one namespace.
+#[derive(Debug, Clone)]
+pub struct ModelFile {
+    namespace: String,
+    version: Option<String>,
+    imports: Vec<Import>,
+    declarations: Vec<Declaration>,
+    local_types: HashMap<String, usize>,
+    file_name: Option<String>,
+}
+
+impl ModelFile {
+    /// Builds a model file from the JSON AST of a `concerto.metamodel@….Model`.
+    pub fn from_json(value: &serde_json::Value, file_name: Option<String>) -> Result<Self> {
+        let namespace = value
+            .get("namespace")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ConcertoError::IllegalModel {
+                message: "model missing 'namespace'".into(),
+                file_name: file_name.clone(),
+                location: None,
+            })?
+            .to_string();
+
+        let version = parse_namespace(&namespace)?.version;
+
+        let imports = match value.get("imports") {
+            None => Vec::new(),
+            Some(serde_json::Value::Array(arr)) => arr
+                .iter()
+                .map(Import::try_from)
+                .collect::<Result<Vec<_>>>()?,
+            Some(_) => {
+                return Err(ConcertoError::IllegalModel {
+                    message: "model 'imports' must be an array".into(),
+                    file_name: file_name.clone(),
+                    location: None,
+                });
+            }
+        };
+
+        let mut declarations = Vec::new();
+        let mut local_types = HashMap::new();
+        match value.get("declarations") {
+            None => {}
+            Some(serde_json::Value::Array(arr)) => {
+                for raw in arr {
+                    let decl = Declaration::try_from(raw).map_err(|e| annotate(e, &file_name))?;
+                    if local_types
+                        .insert(decl.name().to_string(), declarations.len())
+                        .is_some()
+                    {
+                        return Err(ConcertoError::IllegalModel {
+                            message: format!(
+                                "duplicate declaration '{}' in {namespace}",
+                                decl.name()
+                            ),
+                            file_name: file_name.clone(),
+                            location: None,
+                        });
+                    }
+                    declarations.push(decl);
+                }
+            }
+            Some(_) => {
+                return Err(ConcertoError::IllegalModel {
+                    message: "model 'declarations' must be an array".into(),
+                    file_name: file_name.clone(),
+                    location: None,
+                });
+            }
+        }
+
+        Ok(Self {
+            namespace,
+            version,
+            imports,
+            declarations,
+            local_types,
+            file_name,
+        })
+    }
+
+    /// The full namespace, including any version, e.g. `org.example@1.0.0`.
+    pub fn namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    /// The version part of the namespace, if it has one.
+    pub fn version(&self) -> Option<&str> {
+        self.version.as_deref()
+    }
+
+    /// The originating file name, if one was supplied.
+    pub fn file_name(&self) -> Option<&str> {
+        self.file_name.as_deref()
+    }
+
+    /// Every declaration, in the order they appear in the file.
+    pub fn declarations(&self) -> &[Declaration] {
+        &self.declarations
+    }
+
+    /// The imports.
+    pub fn imports(&self) -> &[Import] {
+        &self.imports
+    }
+
+    /// Finds a declaration by its short name.
+    pub fn local_declaration(&self, short: &str) -> Option<&Declaration> {
+        self.local_types.get(short).map(|&i| &self.declarations[i])
+    }
+
+    /// True if this is the built-in `concerto` system namespace.
+    pub fn is_system(&self) -> bool {
+        self.namespace == "concerto" || self.namespace.starts_with("concerto@")
+    }
+
+    /// Resolves a short name using what this file can see by itself: the
+    /// primitives, its own declarations, and its named imports. Returns `None`
+    /// if the only possible match would come through a wildcard, since the
+    /// model manager handles those.
+    pub fn resolve_local(&self, short: &str) -> Option<String> {
+        if is_primitive_type(short) {
+            return Some(short.to_string());
+        }
+        if self.local_types.contains_key(short) {
+            return Some(qualify(&self.namespace, short));
+        }
+        self.imports.iter().find_map(|imp| imp.resolve(short))
+    }
+}
+
+/// Stamps this file's name onto an `IllegalModel` error that came up while
+/// parsing one of its declarations, so the message points somewhere useful.
+fn annotate(err: ConcertoError, file_name: &Option<String>) -> ConcertoError {
+    match err {
+        ConcertoError::IllegalModel {
+            message, location, ..
+        } => ConcertoError::IllegalModel {
+            message,
+            file_name: file_name.clone(),
+            location,
+        },
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> ModelFile {
+        ModelFile::from_json(
+            &serde_json::json!({
+                "$class": "concerto.metamodel@1.0.0.Model",
+                "namespace": "org.example@1.0.0",
+                "imports": [
+                    { "$class": "concerto.metamodel@1.0.0.ImportType",
+                      "namespace": "org.common@1.0.0", "name": "Address" }
+                ],
+                "declarations": [
+                    { "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+                      "name": "Person", "isAbstract": false, "properties": [] }
+                ]
+            }),
+            Some("example.cto".into()),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn parses_namespace_imports_and_declarations() {
+        let mf = sample();
+        assert_eq!(mf.namespace(), "org.example@1.0.0");
+        assert_eq!(mf.version(), Some("1.0.0"));
+        assert_eq!(mf.declarations().len(), 1);
+        assert_eq!(mf.imports().len(), 1);
+        assert!(mf.local_declaration("Person").is_some());
+        assert!(!mf.is_system());
+    }
+
+    #[test]
+    fn resolves_local_primitive_and_import() {
+        let mf = sample();
+        assert_eq!(
+            mf.resolve_local("Person").as_deref(),
+            Some("org.example@1.0.0.Person")
+        );
+        assert_eq!(mf.resolve_local("String").as_deref(), Some("String"));
+        assert_eq!(
+            mf.resolve_local("Address").as_deref(),
+            Some("org.common@1.0.0.Address")
+        );
+        assert_eq!(mf.resolve_local("Missing"), None);
+    }
+
+    #[test]
+    fn duplicate_declaration_is_rejected() {
+        let err = ModelFile::from_json(
+            &serde_json::json!({
+                "$class": "concerto.metamodel@1.0.0.Model",
+                "namespace": "org.dup@1.0.0",
+                "declarations": [
+                    { "$class": "concerto.metamodel@1.0.0.ConceptDeclaration", "name": "A", "isAbstract": false, "properties": [] },
+                    { "$class": "concerto.metamodel@1.0.0.ConceptDeclaration", "name": "A", "isAbstract": false, "properties": [] }
+                ]
+            }),
+            None,
+        );
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn missing_namespace_is_rejected() {
+        let err = ModelFile::from_json(
+            &serde_json::json!({ "$class": "concerto.metamodel@1.0.0.Model" }),
+            None,
+        );
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn non_array_declarations_or_imports_is_rejected() {
+        let bad_decls = ModelFile::from_json(
+            &serde_json::json!({
+                "$class": "concerto.metamodel@1.0.0.Model",
+                "namespace": "org.x@1.0.0",
+                "declarations": { "not": "an array" }
+            }),
+            None,
+        );
+        assert!(bad_decls.is_err());
+
+        let bad_imports = ModelFile::from_json(
+            &serde_json::json!({
+                "$class": "concerto.metamodel@1.0.0.Model",
+                "namespace": "org.x@1.0.0",
+                "imports": "nope"
+            }),
+            None,
+        );
+        assert!(bad_imports.is_err());
+    }
+}

--- a/concerto-core/src/introspect/model_file.rs
+++ b/concerto-core/src/introspect/model_file.rs
@@ -2,10 +2,9 @@
 //!
 //! A [`ModelFile`] owns the declarations and imports of a single namespace and
 //! indexes its declarations by short name. It resolves a short name to a
-//! fully-qualified one from what it can see locally: the primitives, its own
-//! declarations, and its named imports. Wildcard (`ns.*`) imports are left to
-//! the [`ModelManager`](crate::model_manager::ModelManager), which can see the
-//! imported namespaces.
+//! fully-qualified one from what it declares or imports: the primitives, its
+//! own declarations, and its named imports. (Wildcard imports are rejected
+//! while parsing, per strict mode in Concerto v4.)
 
 use std::collections::HashMap;
 
@@ -132,10 +131,9 @@ impl ModelFile {
         self.namespace == "concerto" || self.namespace.starts_with("concerto@")
     }
 
-    /// Resolves a short name using what this file can see by itself: the
+    /// Resolves a short name from what this file declares or imports: the
     /// primitives, its own declarations, and its named imports. Returns `None`
-    /// if the only possible match would come through a wildcard, since the
-    /// model manager handles those.
+    /// if the name is none of those.
     pub fn resolve_local(&self, short: &str) -> Option<String> {
         if is_primitive_type(short) {
             return Some(short.to_string());

--- a/concerto-core/src/lib.rs
+++ b/concerto-core/src/lib.rs
@@ -9,7 +9,12 @@
 
 pub mod error;
 pub mod introspect;
+pub mod model_manager;
 pub mod model_util;
+pub mod rootmodel;
 
 pub use error::{ConcertoError, Result};
-pub use introspect::{ClassDeclaration, ClassKind, Declaration, Property, ScalarDeclaration};
+pub use introspect::{
+    ClassDeclaration, ClassKind, Declaration, Import, ModelFile, Property, ScalarDeclaration,
+};
+pub use model_manager::ModelManager;

--- a/concerto-core/src/model_manager.rs
+++ b/concerto-core/src/model_manager.rs
@@ -1,0 +1,324 @@
+//! Loads model files and resolves types across namespaces.
+//!
+//! The [`ModelManager`] is the only stateful object in the core. It owns the
+//! loaded [`ModelFile`]s and provides the operations that need to see more than
+//! one namespace at once: resolving a type (local, imported, or wildcard),
+//! collecting every property along an inheritance chain, and checking whether
+//! one type is assignable to another. Keeping that state here lets the
+//! validation layer remain a function over already-resolved model state.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::error::{ConcertoError, Result};
+use crate::introspect::declaration::{ClassDeclaration, Declaration};
+use crate::introspect::model_file::ModelFile;
+use crate::introspect::property::Property;
+use crate::model_util::{namespace_of, parse_namespace, qualify, short_name};
+use crate::rootmodel::root_model_ast;
+
+/// Owns a set of model files and resolves types across them.
+#[derive(Debug, Default)]
+pub struct ModelManager {
+    model_files: HashMap<String, ModelFile>,
+}
+
+impl ModelManager {
+    /// A fresh manager with the `concerto@1.0.0` system model already loaded.
+    pub fn new() -> Result<Self> {
+        let mut mgr = Self::default();
+        let root = ModelFile::from_json(&root_model_ast(), Some("concerto@1.0.0".into()))?;
+        mgr.model_files.insert(root.namespace().to_string(), root);
+        Ok(mgr)
+    }
+
+    /// Loads a model from its JSON AST. Loading two models with the same
+    /// namespace is an error.
+    pub fn add_model(
+        &mut self,
+        value: &serde_json::Value,
+        file_name: Option<String>,
+    ) -> Result<()> {
+        let mf = ModelFile::from_json(value, file_name)?;
+        let ns = mf.namespace().to_string();
+        if self.model_files.contains_key(&ns) {
+            return Err(ConcertoError::IllegalModel {
+                message: format!("duplicate namespace: {ns}"),
+                file_name: mf.file_name().map(str::to_string),
+                location: None,
+            });
+        }
+        self.model_files.insert(ns, mf);
+        Ok(())
+    }
+
+    /// The loaded model file for a namespace, if there is one.
+    pub fn model_file(&self, namespace: &str) -> Option<&ModelFile> {
+        self.model_files.get(namespace)
+    }
+
+    /// Looks up a declaration by its fully-qualified name.
+    ///
+    /// Matching ignores the namespace version, so `org.acme@1.0.0.Foo` and
+    /// `org.acme.Foo` resolve to the same declaration.
+    pub fn get_declaration(&self, fqn: &str) -> Result<&Declaration> {
+        let ns = namespace_of(fqn);
+        let short = short_name(fqn);
+
+        if let Some(mf) = self.model_files.get(ns)
+            && let Some(decl) = mf.local_declaration(short)
+        {
+            return Ok(decl);
+        }
+
+        let target_ns = bare_namespace(ns);
+        self.model_files
+            .values()
+            .filter(|mf| bare_namespace(mf.namespace()) == target_ns)
+            .find_map(|mf| mf.local_declaration(short))
+            .ok_or_else(|| ConcertoError::TypeNotFound {
+                type_name: fqn.to_string(),
+            })
+    }
+
+    /// Resolves a short name, as written inside `in_namespace`, to its
+    /// fully-qualified name. Tries primitives, local declarations and named
+    /// imports first, and only then wildcard (`ns.*`) imports.
+    pub fn resolve_type_name(&self, in_namespace: &str, short: &str) -> Result<String> {
+        let mf =
+            self.model_files
+                .get(in_namespace)
+                .ok_or_else(|| ConcertoError::NamespaceNotFound {
+                    namespace: in_namespace.to_string(),
+                })?;
+
+        if let Some(fqn) = mf.resolve_local(short) {
+            return Ok(fqn);
+        }
+
+        for imp in mf.imports().iter().filter(|i| i.is_wildcard()) {
+            if let Some(imported) = self.model_files.get(imp.namespace())
+                && imported.local_declaration(short).is_some()
+            {
+                return Ok(qualify(imp.namespace(), short));
+            }
+        }
+
+        Err(ConcertoError::TypeNotFound {
+            type_name: qualify(in_namespace, short),
+        })
+    }
+
+    /// Every property of a type, gathered by walking from the type up through
+    /// all of its super types. Returns an error if the name is not a
+    /// concept-like type, a super type cannot be resolved, or the inheritance
+    /// chain is circular.
+    pub fn get_all_properties(&self, fqn: &str) -> Result<Vec<&Property>> {
+        Ok(self
+            .super_chain(fqn)?
+            .into_iter()
+            .flat_map(|(_, class)| class.own_properties())
+            .collect())
+    }
+
+    /// Returns `true` if a value of `sub_fqn` is also a valid `super_fqn`: the
+    /// two are the same type, or `sub_fqn` transitively extends `super_fqn`.
+    pub fn is_assignable_to(&self, sub_fqn: &str, super_fqn: &str) -> Result<bool> {
+        let target = bare_fqn(super_fqn);
+        if bare_fqn(sub_fqn) == target {
+            return Ok(true);
+        }
+        match self.get_declaration(sub_fqn)?.as_class() {
+            None => Ok(false),
+            Some(_) => Ok(self
+                .super_chain(sub_fqn)?
+                .iter()
+                .any(|(fqn, _)| bare_fqn(fqn) == target)),
+        }
+    }
+
+    /// Walks a class's inheritance chain, handing back each
+    /// `(full-name, declaration)` pair from the type up to its root.
+    fn super_chain(&self, fqn: &str) -> Result<Vec<(String, &ClassDeclaration)>> {
+        let mut chain = Vec::new();
+        let mut visited = HashSet::new();
+        let mut current = fqn.to_string();
+
+        loop {
+            if !visited.insert(bare_fqn(&current)) {
+                return Err(ConcertoError::IllegalModel {
+                    message: format!("circular inheritance detected at {current}"),
+                    file_name: None,
+                    location: None,
+                });
+            }
+
+            let class = self.get_declaration(&current)?.as_class().ok_or_else(|| {
+                ConcertoError::IllegalModel {
+                    message: format!("{current} is not a concept-like declaration"),
+                    file_name: None,
+                    location: None,
+                }
+            })?;
+
+            let next = self.super_type_fqn(class, namespace_of(&current))?;
+            chain.push((current, class));
+            match next {
+                Some(parent) => current = parent,
+                None => break,
+            }
+        }
+
+        Ok(chain)
+    }
+
+    /// Works out the full name of a class's direct super type, resolved in the
+    /// namespace where the class is declared.
+    fn super_type_fqn(
+        &self,
+        class: &ClassDeclaration,
+        in_namespace: &str,
+    ) -> Result<Option<String>> {
+        let Some(ti) = class.super_type() else {
+            return Ok(None);
+        };
+        if let Some(ns) = &ti.namespace {
+            return Ok(Some(qualify(ns, &ti.name)));
+        }
+        if let Some(resolved) = &ti.resolved_name {
+            return Ok(Some(resolved.clone()));
+        }
+        Ok(Some(self.resolve_type_name(in_namespace, &ti.name)?))
+    }
+}
+
+/// Drops the `@version` off a namespace.
+fn bare_namespace(namespace: &str) -> String {
+    parse_namespace(namespace)
+        .map(|p| p.name)
+        .unwrap_or_else(|_| namespace.to_string())
+}
+
+/// Strips the version off a name's namespace, so two names compare equal
+/// whether or not they were written with one.
+fn bare_fqn(fqn: &str) -> String {
+    let ns = namespace_of(fqn);
+    if ns.is_empty() {
+        return fqn.to_string();
+    }
+    qualify(&bare_namespace(ns), short_name(fqn))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `org.example@1.0.0` with Person ← Employee ← Manager and an enum.
+    fn manager() -> ModelManager {
+        let mut mgr = ModelManager::new().unwrap();
+        mgr.add_model(
+            &serde_json::json!({
+                "$class": "concerto.metamodel@1.0.0.Model",
+                "namespace": "org.example@1.0.0",
+                "declarations": [
+                    { "$class": "concerto.metamodel@1.0.0.ConceptDeclaration", "name": "Person", "isAbstract": false,
+                      "properties": [
+                        { "$class": "concerto.metamodel@1.0.0.StringProperty", "name": "name", "isArray": false, "isOptional": false }
+                      ] },
+                    { "$class": "concerto.metamodel@1.0.0.ConceptDeclaration", "name": "Employee", "isAbstract": false,
+                      "superType": { "$class": "concerto.metamodel@1.0.0.TypeIdentifier", "name": "Person" },
+                      "properties": [
+                        { "$class": "concerto.metamodel@1.0.0.DoubleProperty", "name": "salary", "isArray": false, "isOptional": false }
+                      ] },
+                    { "$class": "concerto.metamodel@1.0.0.ConceptDeclaration", "name": "Manager", "isAbstract": false,
+                      "superType": { "$class": "concerto.metamodel@1.0.0.TypeIdentifier", "name": "Employee" },
+                      "properties": [
+                        { "$class": "concerto.metamodel@1.0.0.StringProperty", "name": "title", "isArray": false, "isOptional": true }
+                      ] },
+                    { "$class": "concerto.metamodel@1.0.0.EnumDeclaration", "name": "Color",
+                      "properties": [ { "$class": "concerto.metamodel@1.0.0.EnumProperty", "name": "RED" } ] }
+                ]
+            }),
+            None,
+        )
+        .unwrap();
+        mgr
+    }
+
+    #[test]
+    fn preloads_system_model() {
+        let mgr = ModelManager::new().unwrap();
+        assert!(mgr.get_declaration("concerto@1.0.0.Concept").is_ok());
+        assert!(mgr.get_declaration("concerto@1.0.0.Asset").is_ok());
+    }
+
+    #[test]
+    fn duplicate_namespace_rejected() {
+        let mut mgr = ModelManager::new().unwrap();
+        let model = serde_json::json!({
+            "$class": "concerto.metamodel@1.0.0.Model",
+            "namespace": "org.x@1.0.0", "declarations": []
+        });
+        mgr.add_model(&model, None).unwrap();
+        assert!(mgr.add_model(&model, None).is_err());
+    }
+
+    #[test]
+    fn resolves_local_and_version_insensitive() {
+        let mgr = manager();
+        assert!(mgr.get_declaration("org.example@1.0.0.Person").is_ok());
+        // version-insensitive lookup
+        assert!(mgr.get_declaration("org.example.Manager").is_ok());
+        assert!(mgr.get_declaration("org.example@1.0.0.Nope").is_err());
+    }
+
+    #[test]
+    fn collects_inherited_properties_in_order() {
+        let mgr = manager();
+        let props = mgr.get_all_properties("org.example@1.0.0.Manager").unwrap();
+        let names: Vec<&str> = props.iter().map(|p| p.name()).collect();
+        // Manager's own first, then Employee, then Person up the chain.
+        assert_eq!(names, ["title", "salary", "name"]);
+    }
+
+    #[test]
+    fn assignability_follows_inheritance() {
+        let mgr = manager();
+        assert!(
+            mgr.is_assignable_to("org.example@1.0.0.Manager", "org.example@1.0.0.Person")
+                .unwrap()
+        );
+        assert!(
+            mgr.is_assignable_to("org.example@1.0.0.Manager", "org.example@1.0.0.Manager")
+                .unwrap()
+        );
+        assert!(
+            !mgr.is_assignable_to("org.example@1.0.0.Person", "org.example@1.0.0.Manager")
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn unresolved_super_type_is_hard_error() {
+        let mut mgr = ModelManager::new().unwrap();
+        mgr.add_model(
+            &serde_json::json!({
+                "$class": "concerto.metamodel@1.0.0.Model",
+                "namespace": "org.broken@1.0.0",
+                "declarations": [
+                    { "$class": "concerto.metamodel@1.0.0.ConceptDeclaration", "name": "Orphan", "isAbstract": false,
+                      "superType": { "$class": "concerto.metamodel@1.0.0.TypeIdentifier", "name": "Ghost" },
+                      "properties": [] }
+                ]
+            }),
+            None,
+        )
+        .unwrap();
+        assert!(mgr.get_all_properties("org.broken@1.0.0.Orphan").is_err());
+    }
+
+    #[test]
+    fn get_all_properties_on_enum_errors() {
+        let mgr = manager();
+        assert!(mgr.get_all_properties("org.example@1.0.0.Color").is_err());
+    }
+}

--- a/concerto-core/src/model_manager.rs
+++ b/concerto-core/src/model_manager.rs
@@ -2,7 +2,7 @@
 //!
 //! The [`ModelManager`] is the only stateful object in the core. It owns the
 //! loaded [`ModelFile`]s and provides the operations that need to see more than
-//! one namespace at once: resolving a type (local, imported, or wildcard),
+//! one namespace at once: resolving a type (local or imported),
 //! collecting every property along an inheritance chain, and checking whether
 //! one type is assignable to another. Keeping that state here lets the
 //! validation layer remain a function over already-resolved model state.
@@ -81,8 +81,8 @@ impl ModelManager {
     }
 
     /// Resolves a short name, as written inside `in_namespace`, to its
-    /// fully-qualified name. Tries primitives, local declarations and named
-    /// imports first, and only then wildcard (`ns.*`) imports.
+    /// fully-qualified name, using the primitives, local declarations and named
+    /// imports the model file can see.
     pub fn resolve_type_name(&self, in_namespace: &str, short: &str) -> Result<String> {
         let mf =
             self.model_files
@@ -91,21 +91,10 @@ impl ModelManager {
                     namespace: in_namespace.to_string(),
                 })?;
 
-        if let Some(fqn) = mf.resolve_local(short) {
-            return Ok(fqn);
-        }
-
-        for imp in mf.imports().iter().filter(|i| i.is_wildcard()) {
-            if let Some(imported) = self.model_files.get(imp.namespace())
-                && imported.local_declaration(short).is_some()
-            {
-                return Ok(qualify(imp.namespace(), short));
-            }
-        }
-
-        Err(ConcertoError::TypeNotFound {
-            type_name: qualify(in_namespace, short),
-        })
+        mf.resolve_local(short)
+            .ok_or_else(|| ConcertoError::TypeNotFound {
+                type_name: qualify(in_namespace, short),
+            })
     }
 
     /// Every property of a type, gathered by walking from the type up through

--- a/concerto-core/src/rootmodel.rs
+++ b/concerto-core/src/rootmodel.rs
@@ -1,0 +1,64 @@
+//! Concerto's built-in system model.
+//!
+//! Every model manager starts with the `concerto@1.0.0` namespace already
+//! loaded. It holds the five abstract base types every user type eventually
+//! extends: `Concept`, `Asset`, `Participant`, `Transaction` and `Event`. We
+//! build the AST in code rather than ship a JSON file, so the two can't drift
+//! out of sync.
+
+const MM: &str = "concerto.metamodel@1.0.0";
+
+fn base_concept(name: &str, identified: bool) -> serde_json::Value {
+    let mut decl = serde_json::json!({
+        "$class": format!("{MM}.ConceptDeclaration"),
+        "name": name,
+        "isAbstract": true,
+        "properties": []
+    });
+    if identified {
+        decl["identified"] = serde_json::json!({ "$class": format!("{MM}.Identified") });
+    }
+    decl
+}
+
+/// The `concerto@1.0.0` system model, as a JSON AST.
+pub fn root_model_ast() -> serde_json::Value {
+    serde_json::json!({
+        "$class": format!("{MM}.Model"),
+        "namespace": "concerto@1.0.0",
+        "imports": [],
+        "declarations": [
+            base_concept("Concept", false),
+            base_concept("Asset", true),
+            base_concept("Participant", true),
+            base_concept("Transaction", false),
+            base_concept("Event", false),
+        ]
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn root_model_defines_five_base_types() {
+        let ast = root_model_ast();
+        assert_eq!(ast["namespace"], "concerto@1.0.0");
+        let decls = ast["declarations"].as_array().unwrap();
+        let names: Vec<&str> = decls.iter().map(|d| d["name"].as_str().unwrap()).collect();
+        assert_eq!(
+            names,
+            ["Concept", "Asset", "Participant", "Transaction", "Event"]
+        );
+    }
+
+    #[test]
+    fn asset_and_participant_are_identified() {
+        let ast = root_model_ast();
+        let decls = ast["declarations"].as_array().unwrap();
+        assert!(decls[1].get("identified").is_some()); // Asset
+        assert!(decls[2].get("identified").is_some()); // Participant
+        assert!(decls[0].get("identified").is_none()); // Concept
+    }
+}


### PR DESCRIPTION
Closes [#1264](https://github.com/accordproject/concerto/issues/1265), closes [#1269](https://github.com/accordproject/concerto/issues/1269)

Finishes the internal representation, on top of #9.

### Changes
- `Import`: typed model imports (wildcard `ns.*`, named, and aliased).
- `ModelFile`: owns one namespace's declarations and imports, indexes them, and
  resolves names it can see locally (primitives, local types, named imports).
- `ModelManager`: loads model files and resolves types across namespaces
  (incl. wildcard imports), walks the inheritance chain to collect a type's
  properties, and checks assignability. Preloads the `concerto@1.0.0` system model.
- Strict AST handling consistent with #9 (rejects missing `$class` and non-array
  `imports`/`declarations`).

### Flags
- A shared `from_json` trait (plus a derive macro in `concerto-macros`) is a
  sensible follow-up, as discussed; kept as methods here.

### Related Issues
- accordproject/concerto#1264
- accordproject/concerto#1269

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:yash/introspection-rest`
```